### PR TITLE
fix: Discord OAuth callback 開放轉址與 token 洩漏 (ZD-2026-00783)

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,7 +66,7 @@ def is_safe_redirect_target(target):
     if not target.startswith("/") or target.startswith(("//", "/\\")):
         return False
     parsed = urllib.parse.urlparse(target)
-    return not parsed.scheme and not parsed.netloc
+    return not (parsed.scheme or parsed.netloc)
 
 
 @app.route("/login")
@@ -244,6 +244,10 @@ def callback():
         and time.time() - state_created <= OAUTH_STATE_MAX_AGE_SECONDS
     )
     if not expected_state or provided_state != expected_state or not state_is_fresh:
+        app.logger.warning(
+            "Rejected /callback: invalid or expired OAuth state (ip=%s)",
+            flask.request.remote_addr,
+        )
         flask.abort(403, description="Invalid or expired OAuth state")
 
     # 轉址目標只從 server-side session 取得（/login 時已白名單檢查過），

--- a/app.py
+++ b/app.py
@@ -2,6 +2,8 @@
 import json
 import os
 import random
+import secrets
+import time
 import traceback
 import urllib.parse
 
@@ -17,6 +19,19 @@ app = flask.Flask(__name__)
 dotenv.load_dotenv(f"{os.getcwd()}/.env", verbose=True, override=True)
 
 app.secret_key = os.getenv("SECRET_KEY")
+
+# Session cookie hardening: block JS access, restrict cross-site sending, and
+# require HTTPS in anything but local debug (set FLASK_DEBUG=true locally to
+# test over plain http, e.g. with `flask run`).
+app.config["SESSION_COOKIE_HTTPONLY"] = True
+app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
+app.config["SESSION_COOKIE_SECURE"] = (
+    os.getenv("FLASK_DEBUG", "false").lower() != "true"
+)
+
+# How long an OAuth "state" nonce (see /login and /callback) stays valid.
+OAUTH_STATE_MAX_AGE_SECONDS = 300
+
 discord_client_id = os.getenv("DISCORD_CLIENT_ID")
 discord_client_secret = os.getenv("DISCORD_CLIENT_SECRET")
 discord_redirect_uri = os.getenv("DISCORD_REDIRECT_URI")
@@ -39,18 +54,44 @@ def not_found_error(error):
     return flask.render_template("404.html"), 404
 
 
+def is_safe_redirect_target(target):
+    """Only allow same-site, relative redirect targets after login.
+
+    Rejects anything that could make the browser leave scaict.org: absolute
+    URLs, protocol-relative URLs ("//evil.com"), and backslash tricks that
+    some browsers still treat as "//" (e.g. "/\\evil.com").
+    """
+    if not target or not isinstance(target, str):
+        return False
+    if not target.startswith("/") or target.startswith(("//", "/\\")):
+        return False
+    parsed = urllib.parse.urlparse(target)
+    return not parsed.scheme and not parsed.netloc
+
+
 @app.route("/login")
 def login():
+    # state 只用來防 CSRF，跟轉址目標完全脫鉤，並且是伺服器產生、一次性、有時效的亂數。
+    state_token = secrets.token_urlsafe(32)
+    flask.session["oauth_state"] = state_token
+    flask.session["oauth_state_created"] = time.time()
+
+    # redirurl 只允許站內相對路徑（白名單邏輯），並存在 server-side session，
+    # 不會被塞進交給 Discord 的 state 參數、也不會被使用者竄改。
     redirurl = flask.request.args.get("redirurl")
+    if is_safe_redirect_target(redirurl):
+        flask.session["oauth_redirect"] = redirurl
+    else:
+        flask.session.pop("oauth_redirect", None)
+
     base_url = "https://discord.com/api/oauth2/authorize"
     params = {
         "client_id": discord_client_id,
         "redirect_uri": discord_redirect_uri,
         "response_type": "code",
         "scope": "identify email",
+        "state": state_token,
     }
-    if redirurl:
-        params["state"] = redirurl
     # 將參數進行 URL 編碼並組合成最終的 URL
     urlencoded = urllib.parse.urlencode(params)
     return flask.redirect(f"{base_url}?{urlencoded}")
@@ -192,7 +233,25 @@ def send(target_user_id):
 @app.route("/callback")
 def callback():
     code = flask.request.args.get("code")
-    redirurl = flask.request.args.get("state")  # 使用 state 作為重定向的目標 URL
+
+    # state 驗證：必須跟 /login 時存進 session 的一次性亂數相符，且沒有過期。
+    # 驗證完立刻 pop 掉，確保不能被重放。
+    expected_state = flask.session.pop("oauth_state", None)
+    state_created = flask.session.pop("oauth_state_created", None)
+    provided_state = flask.request.args.get("state")
+    state_is_fresh = (
+        state_created is not None
+        and time.time() - state_created <= OAUTH_STATE_MAX_AGE_SECONDS
+    )
+    if not expected_state or provided_state != expected_state or not state_is_fresh:
+        flask.abort(403, description="Invalid or expired OAuth state")
+
+    # 轉址目標只從 server-side session 取得（/login 時已白名單檢查過），
+    # 使用者無法透過 state/query string 竄改它。
+    redirurl = flask.session.pop("oauth_redirect", None)
+    if not is_safe_redirect_target(redirurl):
+        redirurl = None
+
     data = {
         "client_id": discord_client_id,
         "client_secret": discord_client_secret,
@@ -233,18 +292,10 @@ def callback():
         user_data["id"], "DCmail", user_data.get("email", "No email provided"), cursor
     )
     cog.core.sql.end(connection, cursor)
-    # 如果 redirurl 存在，將用戶資料作為查詢參數附加到 redirurl 並重定向
-    if redirurl:  # and is_safe_url(redirurl):
-        params = {
-            "username": user_data["username"],
-            "user_id": user_data["id"],
-            "avatar": flask.session["user"]["avatar"],
-            "email": user_data.get("email", "No email provided"),
-            "headers": headers,
-        }
-        urlencoded = urllib.parse.urlencode(params)
-        separator = "&" if "?" in redirurl else "?"
-        return flask.redirect(f"https://{redirurl}{separator}{urlencoded}")
+    # 使用者資料已經存進 session["user"]，目標頁面（站內相對路徑）可以直接讀 session，
+    # 完全不需要、也絕對不能把 email、user id 或 access token 放進轉址網址。
+    if redirurl:
+        return flask.redirect(redirurl)
     # 否則，重定向到 profile 頁面
     return flask.redirect(flask.url_for("profile"))
 


### PR DESCRIPTION
## Summary

修補 HITCON ZeroDay [ZD-2026-00783](https://zeroday.hitcon.org/vulnerability/ZD-2026-00783)：
`/login` 把使用者可控的 `redirurl` 直接塞進 Discord OAuth 的 `state`，`/callback`
再把 `state` 當成轉址目的地（`https://{state}`），並在轉址網址上夾帶 access token
與個人資料，導致惡意建構的登入連結可以把使用者的 Discord 個資 / bearer token
轉送到攻擊者控制的 host。

## 修法

- **`state` 改回純 CSRF nonce**：`/login` 用 `secrets.token_urlsafe(32)` 產生一次性
  亂數存進 server-side session（含時間戳），`/callback` 驗證 `state` 是否相符、
  是否在 5 分鐘內（`OAUTH_STATE_MAX_AGE_SECONDS`），驗證完立即 pop 掉，
  防止重放。驗證失敗回 403。
- **轉址目標白名單化**：新增 `is_safe_redirect_target()`，只允許站內相對路徑
  （擋掉 `//evil.com`、`/\evil.com` 等 protocol-relative / backslash 繞過手法），
  合法的 `redirurl` 存在 server-side session，不再經由 `state` 或 query string
  傳遞，使用者無法竄改。
- **移除轉址網址上的敏感資料**：原本轉址時會把 `username`、`user_id`、
  `avatar`、`email`，甚至整個含 `Authorization: Bearer <token>` 的 `headers`
  dict 塞進 query string 一起送出，這段整個移除。使用者資料本來就已經寫進
  `session["user"]`，目標頁面（現在保證是站內路徑）直接讀 session 即可。
- **Session cookie 加固**：`HttpOnly`、`SameSite=Lax`（OAuth 跨站導回時仍需要
  Lax 才能帶到 session cookie，`Strict` 會壞掉登入流程）、`Secure`（預設開啟，
  本機用 `FLASK_DEBUG=true` 可關閉方便用 http 測試）。

## Test plan

- [x] `pytest tests/` 全部通過（既有測試不受影響）
- [x] `pylint app.py` 10.00/10
- [x] 手動驗證（mock 掉 Discord API 與 DB 層）：
  - 惡意外部 `redirurl` 會被拒絕，回退到 `/`，網址上沒有 token/個資
  - 偽造或不符的 `state` 回 403
  - 合法站內 `redirurl=/slot` 正常運作，轉址網址乾淨（沒有 query string）
  - 同一個 `state` 用兩次，第二次會被拒絕（一次性驗證）
  - `is_safe_redirect_target()` 擋掉 `//evil.com`、`/\evil.com`、帶 tab 的
    `//` 變形、絕對 URL 等已知的 open redirect 繞過手法

Fixes ZD-2026-00783


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Strengthened session cookie protections.
  * Improved OAuth login safeguards with short-lived, single-use verification state.
  * Validated sign-in redirect destinations to prevent unsafe external redirects.
  * Removed sensitive authentication data from redirect URLs.
  * Expired or invalid OAuth callbacks are now rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->