### PR TITLE
fix: 修正禮物發放端點可被 GET 觸發與數量未驗證漏洞 (ZD-2026-00801)

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,6 +36,10 @@ app.config["SESSION_COOKIE_SECURE"] = (
 # How long an OAuth "state" nonce (see /login and /callback) stays valid.
 OAUTH_STATE_MAX_AGE_SECONDS = 300
 
+# Upper bound for a single /api/send gift, mirroring the Discord slash-command
+# gift path (cog/admin_gift.py) rejecting non-positive counts.
+GIFT_AMOUNT_MAX = 100000
+
 discord_client_id = os.getenv("DISCORD_CLIENT_ID")
 discord_client_secret = os.getenv("DISCORD_CLIENT_SECRET")
 discord_redirect_uri = os.getenv("DISCORD_REDIRECT_URI")
@@ -151,8 +155,11 @@ def listt():
     return response.json()
 
 
-@app.route("/api/send/<int:target_user_id>")
-# api/send/{recipient}?gift_type={電電點|抽獎券}count={count}
+@app.route("/api/send/<int:target_user_id>", methods=["POST"])
+# POST api/send/{recipient}?gift_type={電電點|抽獎券}count={count}
+# POST-only so a cross-site top-level navigation (link/img/redirect) can't
+# trigger this as a simple GET request; SameSite=Lax still blocks the cookie
+# on cross-site POSTs.
 def send(target_user_id):
     if not flask.session:
         return flask.jsonify({"result": "you must login", "status": 403})
@@ -187,6 +194,14 @@ def send(target_user_id):
             gift_amount = int(gift_amount)  # 確保 count 是整數
         except ValueError:
             return flask.jsonify({"result": "Invalid count value", "status": 400})
+        # 不能發送 0 以下或超過上限的數量，跟 Discord 斜線指令的驗證保持一致
+        if not 0 < gift_amount <= GIFT_AMOUNT_MAX:
+            return flask.jsonify(
+                {
+                    "result": f"count must be between 1 and {GIFT_AMOUNT_MAX}",
+                    "status": 400,
+                }
+            )
         # 確保目標用戶存在
         user_data = discord_api.get_user(target_user_id)
         if "error" in user_data:


### PR DESCRIPTION
## Summary

修補 HITCON ZeroDay [ZD-2026-00801](https://zeroday.hitcon.org/vulnerability/ZD-2026-00801)：
`/api/send/<target_user_id>` 沒有指定 `methods`，Flask 預設為 GET，配合
`SameSite=Lax` 的 session cookie 在跨站頂層導航（連結、`<img>`、跳轉）時仍會
被帶上，導致攻擊者可誘騙已登入的禮物管理員點擊惡意連結，用管理員身份對
任意使用者發放（或用負數扣除）電電點 / 抽獎券。`count` 也沒有上下限檢查，
可送出超大值或負數。

## 修法

- **路由改為 POST-only**：`SameSite=Lax` 的 cookie 在跨站的 POST 請求
  （表單自動送出或 fetch）不會被送出，關閉本次報告示範的攻擊路徑。
  跟站上其他會改資料的端點（`/buyProduct`、`/rollSlot`）做法一致。
- **`count` 加上界限檢查**：限制在 1~100000（`GIFT_AMOUNT_MAX`），比照
  Discord 斜線指令 (`cog/admin_gift.py`) 拒絕 `count <= 0` 的邏輯，同時
  避免單次發放量異常過大。

## 未處理

沒有另外導入 CSRF token 機制——目前全站（包含 `/buyProduct`、`/rollSlot`）
都沒有 CSRF token 基礎建設，只在這支端點加會不一致，也超出本次修補範圍。

## Test plan

- [x] `python -m black --check app.py`
- [x] `pylint app.py` 10.00/10
- [ ] 手動驗證（需要 Discord/DB 環境）：
  - GET 請求 `/api/send/<id>` 應回 404/405
  - POST 帶合法 `count` (1~100000) 正常發放
  - POST 帶 `count=0`、負數、或超過上限應回 400
  - 非管理員角色的 POST 仍回 403

Fixes ZD-2026-00801